### PR TITLE
Clean up tippecanoe buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,22 +1,36 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-indent() {
-  sed -u 's/^/       /'
-}
+set -eo pipefail
 
-echo "-----> Installing tippecanoe"
+# debug
+# set -x
+
 BUILD_DIR=$1
 
-dep_url=https://github.com/mapbox/tippecanoe.git
-tippecanoe_dir=tippecanoe
-git clone $dep_url -q
-if [ ! -d "$tippecanoe_dir" ]; then
-  echo "[ERROR] Failed to find tippecanoe directory $tippecanoe_dir"
-  exit
-fi
+function indent() {
+  c='s/^/       /'
+  case $(uname) in
+    Darwin) sed -l "$c";;
+    *)      sed -u "$c";;
+  esac
+}
 
-echo "Installing"
+function topic() {
+  echo "-----> $*"
+}
+
+topic "Downloading tippecanoe"
+
+tippecanoe_dir="$BUILD_DIR/tippecanoe"
+mkdir -p $tippecanoe_dir
+
+dep_url=https://github.com/mapbox/tippecanoe.git
+git clone $dep_url $tippecanoe_dir -q | ident
+
+topic "Compiling tippecanoe"
 
 cd $tippecanoe_dir
-make -j
+make -j | ident
+
+topic "Installing tippecanoe"
 make install

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,12 @@ set -eo pipefail
 
 BUILD_DIR=$1
 
+WORK_DIR=$BUILD_DIR/.tippecanoe
+mkdir -p $WORK_DIR
+
+INSTALL_DIR=$BUILD_DIR/vendor
+mkdir -p $INSTALL_DIR
+
 function indent() {
   c='s/^/       /'
   case $(uname) in
@@ -19,18 +25,26 @@ function topic() {
   echo "-----> $*"
 }
 
+topic "Fetching build dependencies"
+
+sudo apt-get install libsqlite3-dev
+
 topic "Downloading tippecanoe"
 
-tippecanoe_dir="$BUILD_DIR/tippecanoe"
-mkdir -p $tippecanoe_dir
+DEP_URL=https://github.com/mapbox/tippecanoe.git
+VERSION="1.34.3"
 
-dep_url=https://github.com/mapbox/tippecanoe.git
-git clone $dep_url $tippecanoe_dir -q | ident
+git clone --depth 1 --branch $VERSION $DEP_URL $WORK_DIR -q
 
-topic "Compiling tippecanoe"
+topic "Compiling tippecanoe binary"
 
-cd $tippecanoe_dir
-make -j | ident
+cd $WORK_DIR
+make -j tippecanoe | indent
 
-topic "Installing tippecanoe"
-make install
+topic "Installing tippecanoe binary"
+
+# we can't `make install` because it assumes writable `/usr/local`
+# also we don't need the other binaries this compiles
+
+cp $WORK_DIR/tippecanoe $INSTALL_DIR
+rm -r $WORK_DIR


### PR DESCRIPTION
some output format cleanups for this buildpack, adapted from https://github.com/remix/puppeteer-heroku-buildpack/blob/master/bin/compile

I looked into build artifact caching, but don't think there's significant advantage. It takes ~15s to compile on my laptop, so probably less on an actual build server. 

caching the source dir is also not very reasonable, it's ~38MB and that's a little beefier than we want to carry around. 