### PR TITLE
Allow .tippecanoe-version to specify entire source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This buildpack clones, compiles, and installs Mapbox's [Tippecanoe](https://gith
 
 ## Configuration
 
-Add a `.tippecanoe-version` file to the source directory of your application to pin the version of tippecanoe that gets installed. If not specified, this buildpack will install the HEAD version of tippecanoe.
+Add a `.tippecanoe-version` file to the source directory of your application to pin the repository and branch of tippecanoe that gets installed. If not specified, this buildpack will install the HEAD version of mainline tippecanoe.
 
 Example `.tippecanoe-version` file:
 
 ```sh
-1.34.3
+--branch 1.34.3 https://github.com/mapbox/tippecanoe.git
 ```
 
 ## Installation

--- a/bin/compile
+++ b/bin/compile
@@ -14,15 +14,13 @@ function step() {
 
 BUILD_DIR=$(cd -- "$1" && pwd)
 
-DEP_URL=https://github.com/mapbox/tippecanoe.git
-VERSION_FILE=$BUILD_DIR/.tippecanoe-version
-VERSION=master
 
-if test -f "$VERSION_FILE"; then
-  VERSION=$(<$VERSION_FILE)
+DOWNLOAD_CMD="https://github.com/mapbox/tippecanoe.git"
+
+SOURCE_OVERRIDE=$BUILD_DIR/.tippecanoe-version
+if test -f "$SOURCE_OVERRIDE"; then
+  DOWNLOAD_CMD=$(<$SOURCE_OVERRIDE)
 fi
-
-DOWNLOAD_CMD="--branch $VERSION $DEP_URL"
 
 WORK_DIR=$BUILD_DIR/.tippecanoe
 mkdir -p $WORK_DIR


### PR DESCRIPTION
We need to apply some of our own hacks to prepare `tippecanoe` for compilation in Heroku's build environment. (extra flags and such)

This change allows the entire source to be specified in the `.tippecanoe-version` file in a repository. 